### PR TITLE
add optional targetFieldName argument to forwardTo()

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,14 +68,15 @@ export function getTypeForRootFieldName(
   return getNamedType(rootField.type) as GraphQLOutputType
 }
 
-export function forwardTo(bindingName: string) {
+export function forwardTo(bindingName: string, targetFieldName?: string) {
   return (parent: any, args: any, context: any, info: GraphQLResolveInfo) => {
-    let message = `Forward to '${bindingName}.${info.parentType.name.toLowerCase()}.${info.fieldName}' failed. `
+    const fieldName = targetFieldName || info.fieldName
+    let message = `Forward to '${bindingName}.${info.parentType.name.toLowerCase()}.${fieldName}' failed. `
     if (context[bindingName]) {
-      if (context[bindingName][info.parentType.name.toLowerCase()][info.fieldName]) {
-        return context[bindingName][info.parentType.name.toLowerCase()][info.fieldName](args, info)
+      if (context[bindingName][info.parentType.name.toLowerCase()][fieldName]) {
+        return context[bindingName][info.parentType.name.toLowerCase()][fieldName](args, info)
       } else {
-        message += `Field '${info.parentType.name.toLowerCase()}.${info.fieldName}' not found on binding '${bindingName}'.`
+        message += `Field '${info.parentType.name.toLowerCase()}.${fieldName}' not found on binding '${bindingName}'.`
       }
     } else {
       message += `Binding '${bindingName}' not found.`


### PR DESCRIPTION
This makes the app bindings to a prismafied legacy graphcool framework
schema easier:

allPosts: forwardTo('db', 'posts')