### PR TITLE
Added generic types to bindings

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -76,7 +76,7 @@ export function getTypeForRootFieldName(
 }
 
 export function forwardTo(bindingName: string) {
-  return (parent: any, args: any, context: any, info: GraphQLResolveInfo) => {
+  return <PARENT, ARGS, CONTEXT>(parent: PARENT, args: ARGS, context: CONTEXT, info: GraphQLResolveInfo) => {
     let message = `Forward to '${bindingName}.${info.parentType.name.toLowerCase()}.${
       info.fieldName
     }' failed. `


### PR DESCRIPTION
If `any` is provided as the type it will remove any type restrictions from the consumer. However, generics act as a type variable so the types can keep flowing.

Small change.