### PR TITLE
feat: request - do not pluck data out but return full response

### DIFF
--- a/src/Delegate.ts
+++ b/src/Delegate.ts
@@ -40,7 +40,7 @@ export class Delegate {
   ): Promise<T> {
     this.before()
     return graphql(this.schema, query, null, null, variables).then(
-      r => r.data as any,
+      r => r as any,
     )
   }
 


### PR DESCRIPTION
This enables `binding.request` function to:-

1. Pass GraphQL error to `binding.request` function callee
2. Support multiple top-level queries with `binding.request` function

Partially fixes: https://github.com/prismagraphql/prisma-binding/issues/182