### PR TITLE
fix: require graphql normally in webpack context

### DIFF
--- a/src/codegen/FlowGenerator.ts
+++ b/src/codegen/FlowGenerator.ts
@@ -1,10 +1,19 @@
-const resolveCwd = require('resolve-cwd')
-const graphqlPackagePath = resolveCwd.silent('graphql')
+declare const __non_webpack_require__
+const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   isNonNullType,
   isListType,
   GraphQLObjectType,
-} = require(graphqlPackagePath || 'graphql')
+} = (isWebpack => {
+  if (isWebpack) {
+    return require('graphql')
+  }
+
+  const resolveCwd = require('resolve-cwd')
+  const graphqlPackagePath = resolveCwd.silent('graphql')
+
+  return require(graphqlPackagePath || 'graphql')
+})(isWebpack)
 
 import { Generator } from './Generator'
 

--- a/src/codegen/FlowGenerator.ts
+++ b/src/codegen/FlowGenerator.ts
@@ -1,19 +1,16 @@
 declare const __non_webpack_require__
-const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   isNonNullType,
   isListType,
   GraphQLObjectType,
 } = (isWebpack => {
-  if (isWebpack) {
-    return require('graphql')
-  }
+  if (isWebpack) return require('graphql')
 
   const resolveCwd = require('resolve-cwd')
   const graphqlPackagePath = resolveCwd.silent('graphql')
 
   return require(graphqlPackagePath || 'graphql')
-})(isWebpack)
+})(typeof __non_webpack_require__ !== 'undefined')
 
 import { Generator } from './Generator'
 

--- a/src/codegen/TypescriptGenerator.ts
+++ b/src/codegen/TypescriptGenerator.ts
@@ -1,5 +1,4 @@
 declare const __non_webpack_require__
-const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   isNonNullType,
   isListType,
@@ -11,7 +10,7 @@ const {
   const graphqlPackagePath = resolveCwd.silent('graphql')
 
   return require(graphqlPackagePath || 'graphql')
-})(isWebpack)
+})(typeof __non_webpack_require__ !== 'undefined')
 
 import {
   GraphQLSchema,

--- a/src/codegen/TypescriptGenerator.ts
+++ b/src/codegen/TypescriptGenerator.ts
@@ -1,10 +1,17 @@
-const resolveCwd = require('resolve-cwd')
-const graphqlPackagePath = resolveCwd.silent('graphql')
+declare const __non_webpack_require__
+const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   isNonNullType,
   isListType,
   GraphQLObjectType,
-} = require(graphqlPackagePath || 'graphql')
+} = (isWebpack => {
+  if (isWebpack) return require('graphql')
+
+  const resolveCwd = require('resolve-cwd')
+  const graphqlPackagePath = resolveCwd.silent('graphql')
+
+  return require(graphqlPackagePath || 'graphql')
+})(isWebpack)
 
 import {
   GraphQLSchema,

--- a/src/info.ts
+++ b/src/info.ts
@@ -1,5 +1,4 @@
 declare const __non_webpack_require__
-const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   GraphQLObjectType,
   GraphQLScalarType,
@@ -13,7 +12,7 @@ const {
   const graphqlPackagePath = resolveCwd.silent('graphql')
 
   return require(graphqlPackagePath || 'graphql')
-})(isWebpack)
+})(typeof __non_webpack_require__ !== 'undefined')
 
 import {
   GraphQLSchema,

--- a/src/info.ts
+++ b/src/info.ts
@@ -1,12 +1,19 @@
-const resolveCwd = require('resolve-cwd')
-const graphqlPackagePath = resolveCwd.silent('graphql')
+declare const __non_webpack_require__
+const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   GraphQLObjectType,
   GraphQLScalarType,
   parse,
   validate,
   Kind,
-} = require(graphqlPackagePath || 'graphql')
+} = (isWebpack => {
+  if (isWebpack) return require('graphql')
+
+  const resolveCwd = require('resolve-cwd')
+  const graphqlPackagePath = resolveCwd.silent('graphql')
+
+  return require(graphqlPackagePath || 'graphql')
+})(isWebpack)
 
 import {
   GraphQLSchema,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,4 @@
 declare const __non_webpack_require__
-const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   GraphQLObjectType,
   GraphQLScalarType,
@@ -15,7 +14,7 @@ const {
   const graphqlPackagePath = resolveCwd.silent('graphql')
 
   return require(graphqlPackagePath || 'graphql')
-})(isWebpack)
+})(typeof __non_webpack_require__ !== 'undefined')
 
 import {
   GraphQLSchema,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
-const resolveCwd = require('resolve-cwd')
-const graphqlPackagePath = resolveCwd.silent('graphql')
+declare const __non_webpack_require__
+const isWebpack = typeof __non_webpack_require__ !== 'undefined'
 const {
   GraphQLObjectType,
   GraphQLScalarType,
@@ -8,7 +8,14 @@ const {
   GraphQLList,
   GraphQLEnumType,
   GraphQLNonNull,
-} = require(graphqlPackagePath || 'graphql')
+} = (isWebpack => {
+  if (isWebpack) return require('graphql')
+
+  const resolveCwd = require('resolve-cwd')
+  const graphqlPackagePath = resolveCwd.silent('graphql')
+
+  return require(graphqlPackagePath || 'graphql')
+})(isWebpack)
 
 import {
   GraphQLSchema,


### PR DESCRIPTION
This is what I came up with for detecting that the library is bundled in webpack and requiring graphql normally. I'm not sure if there is a prettier way, but this is at least a good start.

All tests pass and it works in my serverless function

Fixes #139