### PR TITLE
fix: delegate - data does not exist in value

### DIFF
--- a/src/Delegate.ts
+++ b/src/Delegate.ts
@@ -85,7 +85,7 @@ export class Delegate {
     return {
       async next() {
         const { value } = await iterator.next()
-        const data = { [info.fieldName]: value.data[fieldName] }
+        const data = { [info.fieldName]: value[fieldName] }
         return { value: data, done: false }
       },
       return() {


### PR DESCRIPTION
When trying to use subscriptions through a GraphQL binding I kept getting an error that `'data' was undefined`. After some debugging I found that `value` does not have `data` property inside it that the `delegateSubscription` function was relying on.

I found that the `data` property is already extracted in the [`pushValue` function of apollographql/graphql-tools](https://github.com/apollographql/graphql-tools/blob/master/src/stitching/observableToAsyncIterable.ts#L11-L17). So whatever gets returned on [line 87](https://github.com/graphql-binding/graphql-binding/compare/master...sailci:master#diff-b30eff936716677d237cb3dfd1c8e524R87) is already the contents of `data`.

With the small change in this PR and the fix in https://github.com/apollographql/graphql-tools/pull/928 I was able to get subscriptions working from my GraphQL server talking to a Hasura GraphQL server via a binding.