### PR TITLE
Fix subscriptions

### DIFF
--- a/src/Delegate.ts
+++ b/src/Delegate.ts
@@ -85,7 +85,7 @@ export class Delegate {
     return {
       async next() {
         const { value } = await iterator.next()
-        const data = { [info.fieldName]: value.data[fieldName] }
+        const data = { [info.fieldName]: value[fieldName] }
         return { value: data, done: false }
       },
       return() {


### PR DESCRIPTION
Before this change, creating a subscription would return the following error to the WebSocket subscription:
```json
{
  "error": {
    "name": "TypeError",
    "message": "Cannot read property 'post' of undefined"
  }
}
```

This is because `graphql-tools 3.1.0` nests the result under the subscription key itself (https://github.com/apollographql/graphql-tools/blob/v3.1.0/src/stitching/delegateToSchema.ts#L129) rather than the expected `data` key

Closes #153 