### PR TITLE
fix: generate correct TS types for optional fields

### DIFF
--- a/src/codegen/TypescriptGenerator.ts
+++ b/src/codegen/TypescriptGenerator.ts
@@ -284,7 +284,7 @@ ${this.renderTypes()}`
         const field = type.getFields()[f]
         return `  ${this.renderFieldName(field)}: ${this.renderFieldType(
           field.type,
-        )}`
+        )}${!isNonNullType(field.type) ? ' | null' : ''}`
       })
       .join('\n')
 


### PR DESCRIPTION
Generates additonal `| null` for optional fields as discussed here https://github.com/prisma/prisma-binding/issues/188 and here on [forum](https://www.prisma.io/forum/t/prisma-binding-produces-incorrect-types-for-nullable-update-mutations/3771).