### PR TITLE
Fix mkdirp import

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs'
 import * as yargs from 'yargs'
-import * as mkdirp from 'mkdirp'
+import mkdirp from 'mkdirp'
 import * as path from 'path'
 import { Generator } from './codegen/Generator'
 import { TypescriptGenerator } from './codegen/TypescriptGenerator'


### PR DESCRIPTION
Fixed error on using the cli
```
TypeError: mkdirp is not a function
    at /project/node_modules/graphql-binding/dist/bin.js:105:13
```