### PR TITLE
Changed the order of execution of transformers

### DIFF
--- a/src/Delegate.ts
+++ b/src/Delegate.ts
@@ -160,8 +160,8 @@ export class Delegate {
       context: options && options.context ? options.context : {},
       info,
       transforms: [
-        new ReplaceFieldWithFragment(this.schema, this.fragmentReplacements),
         ...transforms,
+        new ReplaceFieldWithFragment(this.schema, this.fragmentReplacements),
       ],
     })
 


### PR DESCRIPTION
Custom transformers must be executed before "ReplaceFieldWithFragment"

**Example:**

_Api schema:_
```gql

type User {
  id: ID!
  name: String!
}

enum MutationType {
  Created,
  Updated,
  Deleted,
  Unchanged
}

type UpsertUser {
  type: MutationType!
  value: User
}

type Mutation {
  upsertUser(id: ID!, name: String!): UpsertUser!
}
```

_Binding schema:_
```gql

type User {
  id: ID!
  name: String!
}

type Mutation {
  createUser(name: String!): User!
  updateUser(id: ID!, name: String!): User
}
```

_Api resolver:_
```ts

const resolverMap = {
  Mutation: {
    async upsertUser(parent, args, context, info) {
      // if create
      return {
        type: MutationType.Created,
        value: await context.binding.mutation.createUser({ name: args.name}, info, {
          transforms: [
            new ExtractField({
              from: ["createUser", "value"],
              to: ["createUser"]
            })
          ]
        })
      // if update
      return {
        type: MutationType.Updated,
        value: await context.binding.mutation.updateUser(args, info, {
          transforms: [
            new ExtractField({
              from: ["updateUser", "value"],
              to: ["updateUser"]
            })
          ]
        })
      // ...
      };
    }
  }
};
```

**Packages:**
 - graphql-binding: 2.3.8
 - prisma-binding: 2.2.12
