### PR TITLE
src: add option to disable method cache

### DIFF
--- a/src/Binding.ts
+++ b/src/Binding.ts
@@ -41,10 +41,9 @@ export class Binding extends Delegate {
       mutation: this.buildQueryMethods('mutation'),
       subscription: this.buildSubscriptionMethods(),
     }
-    if (this.disableCache) {
-      return methods
+    if (!this.disableCache) {
+      methodCache.set(this.schema, methods)
     }
-    methodCache.set(this.schema, methods)
     return methods
   }
 

--- a/src/Binding.ts
+++ b/src/Binding.ts
@@ -14,14 +14,21 @@ export class Binding extends Delegate {
   query: QueryMap
   mutation: MutationMap
   subscription: SubscriptionMap
+  disableCache: boolean
 
-  constructor({ schema, fragmentReplacements, before }: BindingOptions) {
+  constructor({
+    schema,
+    fragmentReplacements,
+    before,
+    disableCache,
+  }: BindingOptions) {
     super({ schema, fragmentReplacements, before })
 
     const { query, mutation, subscription } = this.buildMethods()
     this.query = query
     this.mutation = mutation
     this.subscription = subscription
+    this.disableCache = disableCache || false
   }
 
   buildMethods() {
@@ -33,6 +40,9 @@ export class Binding extends Delegate {
       query: this.buildQueryMethods('query'),
       mutation: this.buildQueryMethods('mutation'),
       subscription: this.buildSubscriptionMethods(),
+    }
+    if (this.disableCache) {
+      return methods
     }
     methodCache.set(this.schema, methods)
     return methods

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface BindingOptions {
   fragmentReplacements?: FragmentReplacement[]
   schema: GraphQLSchema
   before?: () => void
+  disableCache?: boolean
 }
 
 export interface BindingWithoutSchemaOptions {


### PR DESCRIPTION
This problem is mentioned in detail in #175

Hey there 👋 

Since I'm having to generate multiple schemas dynamically during application runtime, graphql-binding exposes a possible memory leak due to the method cache storing generated methods regardless of the binding instance, creating an uncontrollable factor. Because of this, I'm suggesting we add an opt-in flag to disable setting items in the cache, a simple fix for this problem.

If you've got any questions or suggestions on how to fix this issue, please let me know!