### PR TITLE
fix: Move disableCache to Delegate class

### DIFF
--- a/src/Binding.ts
+++ b/src/Binding.ts
@@ -14,7 +14,6 @@ export class Binding extends Delegate {
   query: QueryMap
   mutation: MutationMap
   subscription: SubscriptionMap
-  disableCache: boolean
 
   constructor({
     schema,
@@ -22,13 +21,12 @@ export class Binding extends Delegate {
     before,
     disableCache,
   }: BindingOptions) {
-    super({ schema, fragmentReplacements, before })
+    super({ schema, fragmentReplacements, before, disableCache })
 
     const { query, mutation, subscription } = this.buildMethods()
     this.query = query
     this.mutation = mutation
     this.subscription = subscription
-    this.disableCache = disableCache || false
   }
 
   buildMethods() {

--- a/src/Delegate.ts
+++ b/src/Delegate.ts
@@ -24,12 +24,19 @@ import * as path from 'path'
 export class Delegate {
   schema: GraphQLSchema
   before: () => void
+  disableCache: boolean
 
   private fragmentReplacements: FragmentReplacement[]
 
-  constructor({ schema, fragmentReplacements, before }: BindingOptions) {
+  constructor({
+    schema,
+    fragmentReplacements,
+    before,
+    disableCache,
+  }: BindingOptions) {
     this.fragmentReplacements = fragmentReplacements || []
     this.schema = schema
+    this.disableCache = disableCache || false
 
     this.before = before || (() => undefined)
   }


### PR DESCRIPTION
This fixes an issue where `disableCache` would be undefined due to inheritance problems, since it had to be moved to the actual Delegate class which the Binding class extends.